### PR TITLE
Remove reference to cheetah

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
 							<h3><a name="git-gui" />Git GUI</h3>
 							<p>As Windows users commonly expect graphical user interfaces, Git for Windows also provides the Git GUI, a powerful alternative to Git BASH, offering a graphical version of just about every Git command line function, as well as comprehensive visual diff tools.</p>
 							<h3><a name="explorer" />Shell Integration</h3>
-							<p>Simply right-click on a folder in Windows Explorer to access the BASH or GUI.  The Git-Cheetah plugin also provides a TortoiseSVN-like interface that displays Git functions directly on the context menu.</p>
+							<p>Simply right-click on a folder in Windows Explorer to access the BASH or GUI.  Additional plugins are available to provide a TortoiseSVN-like interface, displaying Git functions directly on the context menu.</p>
 						</div>
 					</div>
 					<div class="vcentercontainer detailsimg">


### PR DESCRIPTION
The Git for Windows no longer includes Cheetah, and per the [release notes](https://github.com/git-for-windows/build-extra/blob/master/installer/ReleaseNotes.md):

> No longer ships with Git Cheetah (because there are better-maintained Explorer extensions out there).

I'd love to have a page to link to that showcases the "better-maintained Explorer extensions", but at least this provides further separation from Cheetah.