### PR TITLE
Update the Git-for-Windows web page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ http://git-for-windows.github.io/
 2. Install Grunt: `npm install -g grunt-cli`
 3. Install Node.js' dependencies: `cd git-for-windows.github.io && npm install`
 4. Run `grunt` to generate the files
-5. Run `grunt connect` and open http://localhost:4000
-   in your favorite browser to check the changes
+5. Run `grunt connect`
+6. Open `http://localhost:4000` in your favorite browser to check the changes.
 
 (Tested on XP, and onwards)

--- a/index.html
+++ b/index.html
@@ -91,6 +91,7 @@
 							<p>The <i>Git for Windows SDK</i> is a build environment that includes all the tools necessary for developers who want to contribute by writing code for Git for Windows.</p>
 							<p>Please look at the <a href="https://github.com/git-for-windows/git/wiki/Technical-overview">technical overview</a> about the Git for Windows packaging and how to include your changes in your own custom installer.</p>
 							<a name="download-sdk" /><a class="button" href="https://github.com/git-for-windows/build-extra/releases/latest" target="_blank">Download <span class="gittext">Git for Windows SDK</span></a>
+							<p>To contribute/update this web page, see its <a href=" https://github.com/git-for-windows/git-for-windows.github.io">Repository</a>.</p>
 						</div>
 					</div>
 				</div>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 				<a href="index.html"><h1 class="gittext lowercase">Git<span>for Windows</span></h1></a>
 				<div class="version"><a href="https://github.com/git-for-windows/git/releases/tag/v2.7.2.windows.1" title="Version 2.7.2 was published on Tue, 23 Feb 2016 14:14:05 UTC">Version 2.7.2</a></div>
 				<ul class="list-unstyled">
-					<li><a href="https://github.com/git-for-windows/git/wiki/FAQ" target="_blank">FAQ</a></li>
+					<li><a style="font-weight:bold" href="https://github.com/git-for-windows/git/wiki/FAQ" target="_blank">FAQ</a></li>
 					<li><a href="https://github.com/git-for-windows/git" target="_blank">Repository</a></li>
 					<li><a href="http://groups.google.com/group/git-for-windows" target="_blank">Mailing List</a></li>
 				</ul>
@@ -101,7 +101,7 @@
 		<footer>
 			<div class="content">
 				<ul class="list-unstyled">
-					<li><a href="https://github.com/git-for-windows/git/wiki/FAQ" target="_blank">FAQ</a></li>
+					<li><a style="font-weight:bold" href="https://github.com/git-for-windows/git/wiki/FAQ" target="_blank">FAQ</a></li>
 					<li><a href="https://github.com/git-for-windows/git" target="_blank">Repository</a></li>
 					<li><a href="http://groups.google.com/group/git-for-windows" target="_blank">Mailing List</a></li>
 				</ul>


### PR DESCRIPTION
Readers often miss the FAQ link. Make it bold face for better visibility.

Add a link to this web page's repository, after the SDK button to help contributors find it.

Further split the grunt command sequence, as this contributor failed to see the final command
(despite having ran them in the past)

Signed-off-by: Philip Oakley <philipoakley@iee.org>