### PR TITLE
fix determineVersion, add static txt files that have URLs to download

### DIFF
--- a/bump-version.js
+++ b/bump-version.js
@@ -12,7 +12,7 @@ var die = function(err) {
 	process.exit(1);
 };
 
-var updateVersion = function(version, timestamp, url) {
+var updateVersion = function(version, timestamp, url, ver_sub) {
 	var regex = /<div class="version">.*?<\/div>/gm;
 	var replacement = '<div class="version"><a href="' + url
 		+ '" title="Version ' + version + ' was published on '
@@ -22,8 +22,31 @@ var updateVersion = function(version, timestamp, url) {
 			die(err);
 		data = data.replace(regex, replacement);
 		fs.writeFile('index.html', data);
+
+		makeStaticPages(version, ver_sub);
 	});
 };
+
+var makeStaticPages = function(version, ver_sub) {
+	var sep = require('path').sep;
+	var url_pre = 'https://github.com/git-for-windows/git/releases/download/';
+	var dist =	[
+					'Git-latest-32-bit.exe',
+					'Git-latest-32-bit.tar.bz2',
+					'Git-latest-64-bit.exe',
+					'Git-latest-64-bit.tar.bz2',
+					'MinGit-latest-32-bit.zip',
+					'MinGit-latest-64-bit.zip',
+					'PortableGit-latest-32-bit.7z.exe',
+					'PortableGit-latest-64-bit.7z.exe'
+				];
+	var url_full;
+
+	for (var i = 0; i < dist.length; i++) {
+		url_full = url_pre + version + '.windows.' + ver_sub + '/' + dist[i].replace(/-latest-/, '-' + version + '-');
+		fs.writeFile('static' + sep + dist[i] + '.txt', url_full);
+	}
+}
 
 var autoUpdate = function() {
 	Array.prototype.lastElement = function() {
@@ -46,24 +69,35 @@ var autoUpdate = function() {
 		return matches && matches[0];
 	};
 
-	var determineVersion = function(body) {
-		var lines = body.replace(/\n/gm, ',').split(',');
-		var tagName = lines.findFirst(/"tag_name": *"(.*)"/);
-		var regex = /^v(\d+\.\d+\.\d+(\.\d+)?)\.windows\.(\d+)$/;
-		var match = regex.exec(tagName);
-		var version = match[1];
-		if (parseInt(match[3]) > 1)
-			version += '(' + match[3] + ')';
-		var timestamp = lines.findFirst(/"published_at": *"(.*)"/);
-		regex = /^(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)Z$/;
-		match = regex.exec(timestamp);
-		var latest = new Date(match[1], match[2] - 1, match[3],
-			match[4], match[5], match[6], 0).toUTCString();
-		latest = latest.replace(/GMT$/, 'UTC');
-		var url = lines.findFirst(/"html_url": *"(.*)"/);
+	var determineVersion = function(json) {
+		var releases = JSON.parse(json),
+			ver_match = /^v(\d+\.\d+\.\d+(\.\d+)?)\.windows\.(\d+)/,
+			pub_match = /^(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)Z$/,
+			version = false,
+			ver_sub = '',
+			match, latest, url;
+
+		for (var i = 0; i < releases.length && !version; i++) {
+		    if (match = releases[i].tag_name.match(ver_match)) {
+				version = match[1];
+				ver_sub = match[3];
+
+				if (parseInt(match[3]) > 1) {
+					version += '(' + ver_sub + ')';
+				}
+
+				match = releases[i].published_at.match(pub_match);
+				latest = new Date(match[1], match[2] - 1, match[3],
+					match[4], match[5], match[6], 0).toUTCString();
+				latest = latest.replace(/GMT$/, 'UTC');
+				url = releases[i].html_url;
+		    }
+		}
+
 		process.stderr.write('Auto-detected version ' + version
 			+ ' (' + latest + ')\n');
-		return [ version, latest, url ];
+
+		return [ version, latest, url,  ver_sub];
 	};
 
 	var https = require('https');
@@ -82,7 +116,7 @@ var autoUpdate = function() {
 		});
 		res.on('end', function() {
 			var result = determineVersion(https.body);
-			updateVersion(result[0], result[1], result[2]);
+			updateVersion(result[0], result[1], result[2], result[3]);
 		});
 	});
 };
@@ -90,8 +124,7 @@ var autoUpdate = function() {
 if (process.argv.length == 3 && '--auto' == process.argv[2])
 	autoUpdate();
 else if (process.argv.length == 5)
-	updateVersion(process.argv[2], process.argv[3], process.argv[4]);
+	updateVersion(process.argv[2], process.argv[3], process.argv[4], '');
 else
 	die('Usage: node ' + process.argv[1]
 		+ ' <version> <timestamp> <url>\n');
-

--- a/static/.gitignore
+++ b/static/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
The function determineVersion was breaking, instead of trying to work with the releases JSON as text, it was manipulated via JSON.

Per issue #962 creating a static directory and files like:
```
static/Git-latest-32-bit.exe.txt
static/Git-latest-32-bit.tar.bz2.txt
static/Git-latest-64-bit.exe.txt
static/Git-latest-64-bit.tar.bz2.txt
static/MinGit-latest-32-bit.zip.txt
static/MinGit-latest-64-bit.zip.txt
static/PortableGit-latest-32-bit.7z.exe.txt
static/PortableGit-latest-64-bit.7z.exe.txt
```

That would have the corresponding download urls, e.g.:
```
https://github.com/git-for-windows/git/releases/download/2.10.2.windows.1/Git-2.10.2-32-bit.exe
https://github.com/git-for-windows/git/releases/download/2.10.2.windows.1/Git-2.10.2-32-bit.tar.bz2
https://github.com/git-for-windows/git/releases/download/2.10.2.windows.1/Git-2.10.2-64-bit.exe
https://github.com/git-for-windows/git/releases/download/2.10.2.windows.1/Git-2.10.2-64-bit.tar.bz2
https://github.com/git-for-windows/git/releases/download/2.10.2.windows.1/MinGit-2.10.2-32-bit.zip
https://github.com/git-for-windows/git/releases/download/2.10.2.windows.1/MinGit-2.10.2-64-bit.zip
https://github.com/git-for-windows/git/releases/download/2.10.2.windows.1/PortableGit-2.10.2-32-bit.7z.exe
https://github.com/git-for-windows/git/releases/download/2.10.2.windows.1/PortableGit-2.10.2-64-bit.7z.exe
```