### PR TITLE
Add 'Snapshots' link to gitforwindows.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ https://gitforwindows.org/
 
 ## Developing
 
+Note: if you have the cautious 'Use Git from Git Bash only' setting then you may need to change from bash to cmd at step 2, adjusting the cd path at step 3.
+
 0. `git clone https://github.com/git-for-windows/git-for-windows.github.io.git` (this repo) 
 1. Install [Node.js](https://nodejs.org/) (contains the 'npm' package manager)
 2. Install Grunt: `npm install -g grunt-cli`
@@ -15,4 +17,3 @@ https://gitforwindows.org/
 5. Run `grunt connect`
 6. Open `http://localhost:4000` in your favorite browser to check the changes.
 
-(Tested on XP, and onwards)

--- a/index.html
+++ b/index.html
@@ -108,6 +108,7 @@
 					<li><a href="https://github.com/git-for-windows/git" target="_blank">Repository</a></li>
 					<li><a href="http://groups.google.com/group/git-for-windows" target="_blank">Mailing List</a></li>
 					<li><a href="https://github.com/git-for-windows/git/releases/">All Releases</a></li>
+					<li><a href="https://wingit.blob.core.windows.net/files/index.html">Snapshots</a></li>
 					<li><a href="https://github.com/git-for-windows/build-extra/blob/master/ReleaseNotes.md#licenses">Licenses</a></li>
 				</ul>
 				<a href="index.html"><h1 class="gittext lowercase">Git for Windows</h1></a>


### PR DESCRIPTION
Add a link to the Git-For-Windows home page, in the footer, to the snapshots page
on https://wingit.blob.core.windows.net/files/index.html.

As a preparatory step add a small clarification note to the repository
README that caught out this author

Philip