### PR TITLE
Add `.url` files containing direct links to the latest artifacts

### DIFF
--- a/bump-version.js
+++ b/bump-version.js
@@ -19,6 +19,15 @@ var updateVersion = (version, tag, timestamp, url) => {
 		+ timestamp + '">Version ' + version + '</a></div>';
 	fs.writeFileSync('latest-version.txt', version);
 	fs.writeFileSync('latest-tag.txt', tag);
+	const urlPrefix = `https://github.com/git-for-windows/git/releases/download/${tag}`;
+	for (const bitness of ['64', '32']) {
+		fs.writeFileSync(`latest-${bitness}-bit-installer.url`,
+				 `${urlPrefix}/Git-${version}-${bitness}-bit.exe`);
+		fs.writeFileSync(`latest-${bitness}-bit-portable-git.url`,
+				 `${urlPrefix}/PortableGit-${version}-${bitness}-bit.7z.exe`);
+		fs.writeFileSync(`latest-${bitness}-bit-mingit.url`,
+				 `${urlPrefix}/MinGit-${version}-${bitness}-bit.zip`);
+	}
 	fs.readFile('index.html', 'utf8', (err, data) => {
 		if (err)
 			die(err);

--- a/latest-32-bit-installer.url
+++ b/latest-32-bit-installer.url
@@ -1,0 +1,1 @@
+https://github.com/git-for-windows/git/releases/download/v2.31.1.windows.1/Git-2.31.1-32-bit.exe

--- a/latest-32-bit-mingit.url
+++ b/latest-32-bit-mingit.url
@@ -1,0 +1,1 @@
+https://github.com/git-for-windows/git/releases/download/v2.31.1.windows.1/MinGit-2.31.1-32-bit.zip

--- a/latest-32-bit-portable-git.url
+++ b/latest-32-bit-portable-git.url
@@ -1,0 +1,1 @@
+https://github.com/git-for-windows/git/releases/download/v2.31.1.windows.1/PortableGit-2.31.1-32-bit.7z.exe

--- a/latest-64-bit-installer.url
+++ b/latest-64-bit-installer.url
@@ -1,0 +1,1 @@
+https://github.com/git-for-windows/git/releases/download/v2.31.1.windows.1/Git-2.31.1-64-bit.exe

--- a/latest-64-bit-mingit.url
+++ b/latest-64-bit-mingit.url
@@ -1,0 +1,1 @@
+https://github.com/git-for-windows/git/releases/download/v2.31.1.windows.1/MinGit-2.31.1-64-bit.zip

--- a/latest-64-bit-portable-git.url
+++ b/latest-64-bit-portable-git.url
@@ -1,0 +1,1 @@
+https://github.com/git-for-windows/git/releases/download/v2.31.1.windows.1/PortableGit-2.31.1-64-bit.7z.exe


### PR DESCRIPTION
For example, https://gitforwindows.org/latest-64-bit-installer.url will contain the direct link to the latest 64-bit installer, always.

This PR is what I hoped https://github.com/git-for-windows/git/discussions/3020 would give us.