### PR TITLE
Officially drop support for Windows Vista

### DIFF
--- a/requirements.html
+++ b/requirements.html
@@ -46,9 +46,9 @@
 				<h1 id="prerequisites">Prerequisites</h1>
 <p>This page lists the prerequisites required to run <a href="https://gitforwindows.org/">Git for Windows</a>.</p>
 <h2 id="windows-version">Windows version</h2>
-<p>As of Git for Windows v2.10.1, Windows Vista or later are required. The last version of Git for Windows to support Windows XP and Windows Server 2003 is <a href="https://github.com/git-for-windows/git/releases/tag/v2.10.0.windows.1">v2.10.0</a>.</p>
+<p>Git for Windows requires Windows 7 Service Pack 1 or later. The last version to support Windows Vista and Server 2008 was <a href="https://github.com/git-for-windows/git/releases/tag/v2.37.1.windows.1">v2.37.1</a>. The last version of Git for Windows to support Windows XP and Windows Server 2003 is <a href="https://github.com/git-for-windows/git/releases/tag/v2.10.0.windows.1">v2.10.0</a>.</p>
 <p>Why?</p>
-<p>Parts of Git are implemented in shell script, and Git for Windows runs those scripts via <a href="https://msys2.github.io/">MSYS2</a>&#39;s POSIX emulation layer, which in turn is based on the <a href="https://cygwin.com">Cygwin POSIX emulation layer</a>. Seeing as Windows XP and Windows Server 2003 are years past their official end of life, the Cygwin project ended their Herculean efforts to support those Windows versions.</p>
+<p>Parts of Git are implemented in shell script, and Git for Windows runs those scripts via <a href="https://msys2.github.io/">MSYS2</a>&#39;s POSIX emulation layer, which in turn is based on the <a href="https://cygwin.com">Cygwin POSIX emulation layer</a>. Seeing as Windows Vista, Server 2008, XP and Server 2003 are years past their official end of life, the Cygwin project ended their Herculean efforts to support those Windows versions.</p>
 
 			</article>
 		</section>

--- a/requirements.md
+++ b/requirements.md
@@ -4,8 +4,8 @@ This page lists the prerequisites required to run [Git for Windows](https://gitf
 
 ## Windows version
 
-As of Git for Windows v2.10.1, Windows Vista or later are required. The last version of Git for Windows to support Windows XP and Windows Server 2003 is [v2.10.0](https://github.com/git-for-windows/git/releases/tag/v2.10.0.windows.1).
+Git for Windows requires Windows 7 Service Pack 1 or later. The last version to support Windows Vista and Server 2008 was [v2.37.1](https://github.com/git-for-windows/git/releases/tag/v2.37.1.windows.1). The last version of Git for Windows to support Windows XP and Windows Server 2003 is [v2.10.0](https://github.com/git-for-windows/git/releases/tag/v2.10.0.windows.1).
 
 Why?
 
-Parts of Git are implemented in shell script, and Git for Windows runs those scripts via [MSYS2](https://msys2.github.io/)'s POSIX emulation layer, which in turn is based on the [Cygwin POSIX emulation layer](https://cygwin.com). Seeing as Windows XP and Windows Server 2003 are years past their official end of life, the Cygwin project ended their Herculean efforts to support those Windows versions.
+Parts of Git are implemented in shell script, and Git for Windows runs those scripts via [MSYS2](https://msys2.github.io/)'s POSIX emulation layer, which in turn is based on the [Cygwin POSIX emulation layer](https://cygwin.com). Seeing as Windows Vista, Server 2008, XP and Server 2003 are years past their official end of life, the Cygwin project ended their Herculean efforts to support those Windows versions.


### PR DESCRIPTION
The plan to do this had been announced already for a while.