### PR TITLE
bump-version: create url files for arm64 artifacts

### DIFF
--- a/bump-version.js
+++ b/bump-version.js
@@ -20,13 +20,13 @@ var updateVersion = (version, tag, timestamp, url) => {
 	fs.writeFileSync('latest-version.txt', version);
 	fs.writeFileSync('latest-tag.txt', tag);
 	const urlPrefix = `https://github.com/git-for-windows/git/releases/download/${tag}`;
-	for (const bitness of ['64', '32']) {
-		fs.writeFileSync(`latest-${bitness}-bit-installer.url`,
-				 `${urlPrefix}/Git-${version}-${bitness}-bit.exe`);
-		fs.writeFileSync(`latest-${bitness}-bit-portable-git.url`,
-				 `${urlPrefix}/PortableGit-${version}-${bitness}-bit.7z.exe`);
-		fs.writeFileSync(`latest-${bitness}-bit-mingit.url`,
-				 `${urlPrefix}/MinGit-${version}-${bitness}-bit.zip`);
+	for (const suffix of ['64-bit', '32-bit', 'arm64']) {
+		fs.writeFileSync(`latest-${suffix}-installer.url`,
+				 `${urlPrefix}/Git-${version}-${suffix}.exe`);
+		fs.writeFileSync(`latest-${suffix}-portable-git.url`,
+				 `${urlPrefix}/PortableGit-${version}-${suffix}.7z.exe`);
+		fs.writeFileSync(`latest-${suffix}-mingit.url`,
+				 `${urlPrefix}/MinGit-${version}-${suffix}.zip`);
 	}
 	fs.readFile('index.html', 'utf8', (err, data) => {
 		if (err)

--- a/latest-arm64-installer.url
+++ b/latest-arm64-installer.url
@@ -1,0 +1,1 @@
+https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/Git-2.47.1-arm64.exe

--- a/latest-arm64-mingit.url
+++ b/latest-arm64-mingit.url
@@ -1,0 +1,1 @@
+https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/MinGit-2.47.1-arm64.zip

--- a/latest-arm64-portable-git.url
+++ b/latest-arm64-portable-git.url
@@ -1,0 +1,1 @@
+https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/PortableGit-2.47.1-arm64.7z.exe


### PR DESCRIPTION
Since we create release artifacts for ARM64 now we should also create the same URL files for ARM64 as we do for other architectures.