### PR TITLE
Stop linking to Twitter

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -82,5 +82,7 @@ To contribute/update this web page, see its [Repository]( https://github.com/git
 </div>
 </div>
 <div class="stud">
-<a href="https://twitter.com/GitForWindows" rel="publisher">Twitter</a>
+
+<a href="https://bsky.app/profile/gitforwindows.org" rel="publisher">Bluesky</a>
+
 </div>


### PR DESCRIPTION
For easily-guessable reasons, Git for Windows no longer posts on Twitter (for quite some time, actually), but [on Bluesky](https://bsky.app/profile/gitforwindows.org) instead.