### PR TITLE
Stop mentioning the shut-down Google Group

### DIFF
--- a/content/governance-model.md
+++ b/content/governance-model.md
@@ -51,7 +51,7 @@ Contributors are community members who either have no desire to become committer
 yet been given the opportunity by the benevolent dictator. They make valuable contributions, such as
 those outlined in the list below, but generally do not have the authority to make direct changes to the
 project code. Contributors engage with the project through communication tools, such as the
-[mailing list](https://groups.google.com/forum/#!forum/git-for-windows),
+[Git mailing list](mailto:git@vger.kernel.org),
 [GitHub](https://github.com/git-for-windows), via [reports of issues](https://github.com/git-for-windows/git/issues)
 and via [pull requests](https://github.com/git-for-windows/git/pulls) in the issue tracker, as detailed in our
 [how to participate](https://github.com/git-for-windows/git/wiki/How-to-participate) document.

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -3,7 +3,7 @@
 		<ul class="list-unstyled">
 			<li><a{{ if eq "home" .Kind }} style="font-weight:bold"{{end}} href="https://github.com/git-for-windows/git/wiki/FAQ" target="_blank">FAQ</a></li>
 			<li><a href="https://github.com/git-for-windows/git" target="_blank">Repository</a></li>
-			<li><a href="http://groups.google.com/group/git-for-windows" target="_blank">Mailing List</a></li>
+			<li><a href="https://github.com/git-for-windows/git/discussions/" target="_blank">Discussions</a></li>
 			{{- if eq "home" .Kind }}
 			<li><a href="https://github.com/git-for-windows/git/releases/">All Releases</a></li>
 			<li><a href="https://gitforwindows.org/git-snapshots/">Snapshots</a></li>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,7 +5,7 @@
 		<ul class="list-unstyled">
 			<li><a style="font-weight:bold" href="https://github.com/git-for-windows/git/wiki/FAQ" target="_blank">FAQ</a></li>
 			<li><a href="https://github.com/git-for-windows/git" target="_blank">Repository</a></li>
-			<li><a href="https://groups.google.com/group/git-for-windows" target="_blank">Mailing List</a></li>
+			<li><a href="https://github.com/git-for-windows/git/discussions/" target="_blank">Discussions</a></li>
 		</ul>
 	</nav>
 	<section class="content feature">


### PR DESCRIPTION
As per https://github.com/git-for-windows/git/discussions/5473, Git for Windows' Google Group is shut down.