### PR TITLE
Drop 32-bit and add ARM64 architecture check

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -38,16 +38,19 @@
 				{{ if eq "home" .Kind -}}
 				/* Replace the download link if a Windows browser was detected */
 				try {
-					var agent = window.navigator.userAgent;
 					var href = $('.version > a')[0].href.match(/^(.*\/)tag(\/.*)$/);
 					var version = $('.version > a')[0].title.match(/^Version ([0-9.]*)(\(([0-9]*)?\))?/);
-					if (!agent.match(/Windows/) || !href || !version)
+					if (!href || !version || !navigator.userAgentData)
 						throw 0;
-					var bitness = agent.match(/(WOW|Win)64/) ? '64' : '32';
-					if (version[2])
-						version[1] += '.' + version[3];
-					var url = href[1] + 'download' + href[2] + '/Git-' + version[1] + '-' + bitness + '-bit.exe';
-					$('a.button:contains("Download")')[0].href = url;
+
+					navigator.userAgentData.getHighEntropyValues(["architecture", "platform", "bitness"])
+					.then(function(browser) {
+						if (browser.platform != "Windows" || browser.bitness != "64") return;
+
+						var architecture = browser.architecture == "arm" ? "arm64" : "64-bit";
+						var url = href[1] + 'download' + href[2] + '/Git-' + version[1] + '-' + architecture + '.exe';
+						$('a.button:contains("Download")')[0].href = url;
+					})
 				} catch(e) {}
 				{{ end -}}
 			});


### PR DESCRIPTION
New Git-For-Windows does not have Git-32-bit.exe, drop 32-Bit.
Add ARM64 architecture check, I find this check code in VSCode website.

I do not test it, So please test it at first