### PR TITLE
Fix download button href replace

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -45,7 +45,7 @@
 
 						var architecture = browser.architecture == "arm" ? "arm64" : "64-bit";
 						var url = href[1] + 'download' + href[2] + '/Git-' + version[1] + '-' + architecture + '.exe';
-						$('a.button:contains("Download")')[0].href = url;
+						document.getElementById("download").href = url;
 					})
 				} catch(e) {}
 				{{ end -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -17,7 +17,7 @@
 			<div class="vcentercontainer">
 				<div>
 					<h2>We bring the awesome <span class="gittext">Git</span> SCM to Windows</h2>
-					<a name="download" /><a class="button featurebutton" href="https://github.com/git-for-windows/git/releases/latest" target="_blank">Download</a>
+					<a id="download" class="button featurebutton" href="https://github.com/git-for-windows/git/releases/latest" target="_blank">Download</a>
 					<a class="button featurebutton" href="#contribute">Contribute</a>
 				</div>
 			</div>


### PR DESCRIPTION
jQuery was dropped

Link: https://github.com/git-for-windows/git-for-windows.github.io/pull/62

Replace download button href replace to `getElementById`