### PR TITLE
Really avoid any jQuery construct

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -34,8 +34,9 @@
 				{{ if eq "home" .Kind -}}
 				/* Replace the download link if a Windows browser was detected */
 				try {
-					var href = $('.version > a')[0].href.match(/^(.*\/)tag(\/.*)$/);
-					var version = $('.version > a')[0].title.match(/^Version ([0-9.]*)(\(([0-9]*)?\))?/);
+					var a = document.querySelector('.version > a')
+					var href = a?.href.match(/^(.*\/)tag(\/.*)$/);
+					var version = a?.title.match(/^Version ([0-9.]*)(\(([0-9]*)?\))?/);
 					if (!href || !version || !navigator.userAgentData)
 						throw 0;
 


### PR DESCRIPTION
In https://github.com/git-for-windows/git-for-windows.github.io/pull/76, I merged a contribution that purported to fix the problem that the download button no longer pointed to the appropriate installer.

The underlying root cause is that that logic relied on jQuery, but we recently got rid of it (because our copy was ridiculously outdated).

The problem with that PR is that it had an incomplete solution, still leaving `$(...)` calls in place.

This here commit fixes that.