### PR TITLE
requirements, 32-bit: clarify end of 32-bit installer support

### DIFF
--- a/content/32-bit.md
+++ b/content/32-bit.md
@@ -5,19 +5,21 @@ title: 32-bit
 
 While Git for Windows v1.x was only ever offered as 32-bit installer (i.e. targeting the i686 CPU architecture), with the switch of Git for Windows v2.x in August 2015 to depend on [MSYS2](https://www.msys2.org/), there have been two variants: the 32-bit and the 64-bit (x86\_64) one.
 
-However, due to Git for Windows' reliance on the MSYS2, which [dropped 32-bit support](https://www.msys2.org/news/#2020-05-17-32-bit-msys2-no-longer-actively-supported) (the 32-bit version of the MSYS2 runtime [cannot even be built](https://github.com/msys2/msys2-runtime/commit/762dcfc658c85de8d418c6ba4e0e40024bee118a) as of version 3.4.0), Git for Windows will start to phase out 32-bit support after Git for Windows v2.40.x.
+However, due to Git for Windows' reliance on the MSYS2, which [dropped 32-bit support](https://www.msys2.org/news/#2020-05-17-32-bit-msys2-no-longer-actively-supported) (the 32-bit version of the MSYS2 runtime [cannot even be built](https://github.com/msys2/msys2-runtime/commit/762dcfc658c85de8d418c6ba4e0e40024bee118a) as of version 3.4.0), Git for Windows started to phase out 32-bit support after Git for Windows v2.40.x.
 
 ## Timeline
 
 ### March 2023: End of full 32-bit support
 
-The last major Git for Windows version with full 32-bit support will be v2.40.x.
+The last major Git for Windows version with full 32-bit support was v2.40.x.
 
-### Until 2025: Limited 32-bit support
+### Until February 2025: Limited 32-bit support
 
-The 32-bit variant of Git for Windows will still be offered, but not all of the components distributed with Git for Windows will necessarily be updated as for the 64-bit variant.
+The 32-bit variant of Git for Windows was still offered, but not all of the components distributed with Git for Windows were necessarily updated as for the 64-bit variant.
 
-For example, 64-bit Git for Windows v2.41.x will ship with the MSYS2 runtime v3.4.x, while 32-bit Git for Windows will remain with v3.3.6 forever.
+For example, 64-bit Git for Windows v2.41.x shipped with the MSYS2 runtime v3.4.x, while 32-bit Git for Windows remained with v3.3.6 forever.
+
+As a parting gift to 32-bit users, [v2.48.1](https://github.com/git-for-windows/git/releases/tag/v2.48.1.windows.1) was the last version to ship with the 32-bit installer, Portable Git and archive.
 
 ### Until 2029: MinGit-only 32-bit support
 

--- a/content/requirements.md
+++ b/content/requirements.md
@@ -7,7 +7,9 @@ This page lists the prerequisites required to run [Git for Windows](https://gitf
 
 ## Windows version
 
-Git for Windows requires Windows 8.1 or later on i686 and x86_64 CPU architectures. The last version to support Windows 7, 8, Server 2008 R2 and Server 2012 was [v2.46.2](https://github.com/git-for-windows/git/releases/tag/v2.46.2.windows.1). The last version to support Windows Vista and Server 2008 was [v2.37.1](https://github.com/git-for-windows/git/releases/tag/v2.37.1.windows.1). The last version of Git for Windows to support Windows XP and Windows Server 2003 is [v2.10.0](https://github.com/git-for-windows/git/releases/tag/v2.10.0.windows.1).
+Git for Windows requires Windows 8.1 or later on a 64-bit CPU (x64 or amd64). The last version to support Windows 7, 8, Server 2008 R2 and Server 2012 was [v2.46.2](https://github.com/git-for-windows/git/releases/tag/v2.46.2.windows.1). The last version to support Windows Vista and Server 2008 was [v2.37.1](https://github.com/git-for-windows/git/releases/tag/v2.37.1.windows.1). The last version of Git for Windows to support Windows XP and Windows Server 2003 is [v2.10.0](https://github.com/git-for-windows/git/releases/tag/v2.10.0.windows.1).
+
+The last version with full 32-bit (i686) support was [v2.40.x](https://github.com/git-for-windows/git/releases/tag/v2.40.1.windows.1). Since then, the only official 32-bit artifact is [MinGit](https://gitforwindows.org/mingit.html), a minimal subset intended for third-party applications. Full 32-bit installers and Portable Git are no longer provided. For details, see the [32-bit support timeline](https://gitforwindows.org/32-bit.html).
 
 Why?
 

--- a/content/requirements.md
+++ b/content/requirements.md
@@ -9,7 +9,7 @@ This page lists the prerequisites required to run [Git for Windows](https://gitf
 
 Git for Windows requires Windows 8.1 or later on a 64-bit CPU (x64 or amd64). The last version to support Windows 7, 8, Server 2008 R2 and Server 2012 was [v2.46.2](https://github.com/git-for-windows/git/releases/tag/v2.46.2.windows.1). The last version to support Windows Vista and Server 2008 was [v2.37.1](https://github.com/git-for-windows/git/releases/tag/v2.37.1.windows.1). The last version of Git for Windows to support Windows XP and Windows Server 2003 is [v2.10.0](https://github.com/git-for-windows/git/releases/tag/v2.10.0.windows.1).
 
-The last version with full 32-bit (i686) support was [v2.40.x](https://github.com/git-for-windows/git/releases/tag/v2.40.1.windows.1). Since then, the only official 32-bit artifact is [MinGit](https://gitforwindows.org/mingit.html), a minimal subset intended for third-party applications. Full 32-bit installers and Portable Git are no longer provided. For details, see the [32-bit support timeline](https://gitforwindows.org/32-bit.html).
+The last version with full 32-bit (i686) support was v2.40.x. After that, 32-bit installers continued to be offered with reduced component updates; the last version to ship with the 32-bit installer, Portable Git and archive was [v2.48.1](https://github.com/git-for-windows/git/releases/tag/v2.48.1.windows.1). Since then, the only official 32-bit artifact is [MinGit](https://gitforwindows.org/mingit.html), a minimal subset intended for third-party applications. For details, see the [32-bit support timeline](https://gitforwindows.org/32-bit.html).
 
 Why?
 


### PR DESCRIPTION
The requirements page claimed that Git for Windows supports both i686 and x86_64 CPU architectures, which has not been accurate for a while. Full 32-bit support ended with v2.40.x in March 2023, and the 32-bit timeline page was still written in future tense despite this phase having concluded.

Additionally, while the limited 32-bit support phase (shipping installers with reduced component updates) was meant to wind down quietly, the embargoed security release v2.48.1 ended up accidentally including 32-bit installers as well. Rather than trying to undo that, this was accepted as one last, gracious parting gift to 32-bit users and is now definitively the last version with a 32-bit installer, Portable Git and archive.

This PR:

- Updates the requirements page to say "64-bit CPU (x64 or amd64)" and adds a paragraph explaining the 32-bit deprecation with a link to the timeline page.
- Notes v2.48.1 as the last version to ship with 32-bit installer, Portable Git and archive on both pages.
- Switches the 32-bit timeline page from future tense to past tense.
