### PR TITLE
layouts: adopt git-scm.com's alias template to preserve query strings and anchors

### DIFF
--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -1,0 +1,15 @@
+{{ $redirect_to := replaceRE `\.html$` "" (replace .Permalink "?" "%3F") }}
+<html lang="en">
+ <head>
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ $redirect_to }}">
+  <meta http-equiv="refresh" content="0; url={{ $redirect_to }}">
+  <meta name="robots" content="noindex">
+ </head>
+ <body>
+  <script>window.location.replace(document.querySelector("link[rel='canonical']").href + window.location.search + window.location.hash)</script>
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ $redirect_to }}">Click here if you are not redirected.</a>
+ </body>
+</html>


### PR DESCRIPTION
Hugo's built-in alias pages use a bare `<meta http-equiv="refresh">` redirect, which discards any query string or URL fragment from the original request. This means that if someone follows a link like `https://gitforwindows.org/FAQ.html#some-heading`, the redirect to `faq.html` loses the `#some-heading` anchor.

This adopts the custom `alias.html` layout from [git-scm.com](https://github.com/git/git-scm.com), which enhances the redirect with JavaScript that appends `window.location.search` and `window.location.hash` to the redirect target. The `<meta http-equiv="refresh">` remains as a no-JavaScript fallback (which still loses query strings and anchors, but at least lands on the right page).
