### PR TITLE
add update-faq-security-version.js

### DIFF
--- a/update-faq-security-version.js
+++ b/update-faq-security-version.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+/*
+ * Updates the FAQ's "Should I upgrade?" section to mention a new
+ * security-relevant Git for Windows version.
+ *
+ * Usage: node update-faq-security-version.js <display-version>
+ *
+ * Example: node update-faq-security-version.js '2.53.0(3)'
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const die = (msg) => {
+	process.stderr.write(msg + '\n')
+	process.exit(1)
+}
+
+const version = process.argv[2]
+if (!version) die('Usage: node update-faq-security-version.js <display-version>')
+
+const faqPath = path.join(__dirname, 'content', 'faq.md')
+const faq = fs.readFileSync(faqPath, 'utf-8')
+
+const marker = 'it is *highly* advisable to upgrade.'
+const re = /^(If you have a version older than )\S+?(, it is \*highly\* advisable to upgrade\. A couple of Git versions came with important fixes to security-relevant vulnerabilities: )(.*)$/m
+const match = faq.match(re)
+if (!match) die('Could not find the security-versions line in content/faq.md')
+
+const existingList = match[3]
+if (existingList.startsWith(version + ',') || existingList.startsWith(version + ' ')) {
+	process.stderr.write(version + ' is already listed; nothing to do.\n')
+	process.exit(0)
+}
+
+const updated = faq.replace(re, `$1${version}$2${version}, ${existingList}`)
+fs.writeFileSync(faqPath, updated)
+process.stderr.write('Updated FAQ to recommend upgrading to at least ' + version + '\n')


### PR DESCRIPTION
Every time a security release of Git for Windows is published, the FAQ's "Should I upgrade?" section needs to be updated to recommend upgrading to (at least) the latest security-fix version. This is easy to forget amidst the many steps of an embargoed release, as demonstrated this past Tuesday when the FAQ update was only remembered a day later.

This script automates that step. It takes a display version (e.g. `2.53.0(3)`) as argument, updates the "older than" threshold, and prepends the version to the comma-separated list of security-fix releases. It is idempotent: if the version is already listed, it exits cleanly without changes.

Analogous to how `bump-version.js` updates `hugo.yml` with the latest version metadata, this script is intended to be called as part of the embargoed release process automation so that the FAQ update is never forgotten again.