### PR TITLE
workflows: bump GitHub Actions to their latest major versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: configure Hugo
         run: |
           set -x &&
@@ -33,7 +33,7 @@ jobs:
           deb=hugo_extended_${HUGO_VERSION}_linux-amd64.deb &&
           curl -LO https://github.com/gohugoio/hugo/releases/download/v$HUGO_VERSION/$deb &&
           sudo dpkg -i $deb
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
         id: pages
       - name: run Hugo to build the pages
         env:
@@ -44,8 +44,8 @@ jobs:
       - uses: actions/setup-node@v6
       - name: pre-render the Graphviz diagrams
         run: npm install && node ./script/graphviz-ssr.js
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: ./public
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v5
         id: deployment

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: configure Hugo
       run: |
         set -x &&
@@ -22,7 +22,7 @@ jobs:
     - name: build tar archive
       run: cd public && tar czvf ../pages.tar.gz *
     - name: Upload build artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: pages
         path: pages.tar.gz


### PR DESCRIPTION
Keeping the pinned action versions current avoids accumulating deprecation warnings on every workflow run and ensures we benefit from upstream fixes (in particular for the Node.js runtime the actions execute under, which the `actions/*` repositories bump from time to time when older Node versions are deprecated on GitHub Actions runners).

The bumps are:

| Action | Old | New |
| --- | --- | --- |
| `actions/checkout` | v4 | v7 |
| `actions/configure-pages` | v5 | v6 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |
| `actions/upload-artifact` | v4 | v7 |

`actions/setup-node` was already pinned to the current latest major (v6) and needs no change.
